### PR TITLE
Fix stdin control flow and update store initialisation

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,11 +14,11 @@ func main() {
 	fmt.Println("Welcome to the key-value store. Initialising...")
 	store := storage.NewKVStore()
 	fmt.Println("Ready")
-	run()
+	run(store)
 	defer fmt.Println("Exiting key-value store")
 }
 
-func run() {
+func run(store *storage.KVStore) {
 	for {
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Print("Enter command: ")
@@ -27,32 +27,33 @@ func run() {
 			panic(err)
 		}
 		log.Printf("Input received: %s", cmd)
-		process(cmd)
+		process(cmd, store)
 	}
 }
 
-func process() {
+func process(cmd string, store *storage.KVStore) {
 	c := strings.Fields(cmd)
 	switch c[0] {
 	case "get":
-		if len(c) != 1 {
-			fmt.Print("Incorrect command supplied. please use \"get <yourkey>\"")
+		if len(c[1:]) != 1 {
+			fmt.Println("Incorrect command supplied. please use \"get <yourkey>\"")
+			break
 		}
 		log.Printf("Processing get request")
 		key := c[1]
 		store.Get(key)
 	case "set":
-		if len(c) != 2 {
-			fmt.Print("Incorrect command supplied. please use \"set <yourkey> <yourvalue>\"")
+		if len(c[1:]) != 2 {
+			fmt.Println("Incorrect command supplied. please use \"set <yourkey> <yourvalue>\"")
+			break
 		}
 		log.Printf("Processing set request")
-		key := c[1]
-		val := c[2]
+		key, val := c[1], c[2]
 		store.Set(key, val)
 	case "exit":
-		log.Printf("Thanks for visiting the key-value store. Exiting.")
+		log.Printf("Thanks for visiting the key-value store.")
 		os.Exit(0)
 	default:
-		fmt.Print("Incorrect command supplied. hint: see README and try again")
+		fmt.Println("Incorrect command supplied. hint: see README and try again")
 	}
 }

--- a/pkg/storage/encode.go
+++ b/pkg/storage/encode.go
@@ -1,0 +1,17 @@
+package storage
+
+import (
+	"bytes"
+	"encoding/gob"
+	"log"
+)
+
+// StrToBytes : Takes a string and encodes to bytes
+func StrToBytes(str string) []byte {
+	log.Printf("Encoding string %s to bytes", str)
+	buff := &bytes.Buffer{}
+	gob.NewEncoder(buff).Encode(str)
+	bs := buff.Bytes()
+	log.Printf("Successfully encoded. Result: %v", bs)
+	return bs
+}

--- a/pkg/storage/kvstore.go
+++ b/pkg/storage/kvstore.go
@@ -7,8 +7,6 @@ import (
 const (
 	// fanout : ratio between levels of LSM-tree e.g. C2 = C1 * fanout
 	fanout int = 2
-	// initL : inital levels of LSM-tree. 1 = Memtable (C0) only, 2 = Memtable (C0) + C1
-	initL int = 1
 )
 
 type storage interface {
@@ -26,12 +24,11 @@ type KVStore struct {
 // NewKVStore : instantiates a new key-value store with some default values
 func NewKVStore() *KVStore {
 	log.Printf("Instantiating a new key-value store")
-	log.Printf("Setting attributes: Memtable as buffer, initial levels as %d and level growth factor of %d", levels, fanout)
+	log.Printf("Setting attributes: Memtable as buffer and level growth factor of %d", fanout)
 
 	mt := new(Memtable)
 	kvs := &KVStore{
 		buffer: mt,
-		levels: initL,
 		fanout: fanout}
 
 	log.Printf("Key-value store instantiated")
@@ -43,11 +40,13 @@ WRITE OPERATIONS
 */
 
 // Set : Main function to set a key in the key-value store
-func (kvs *KVStore) Set(key string, value []byte) error {
+func (kvs *KVStore) Set(key string, value string) error {
 	log.Printf("Setting key %s", key)
 	mt := kvs.buffer
 
-	mt.InsertToMemtable(key, value)
+	val := StrToBytes(value)
+
+	mt.InsertToMemtable(key, val)
 
 	switch f := mt.IsMemtableFull(); f {
 	case true:


### PR DESCRIPTION
## Overview
This PR fixes some bugs in the top level of the store, namely the control flow of how stdin commands are handled and how the `KVStore` is initialised

## Details
* Breaks added to `if{}` blocks in switch statement that handles stdin get and set commands
* `Store` initialised with correct fields when main program is started
* Helper function added to handle `StrToByte` conversion