### PR TITLE
Development 20200515

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,13 +12,14 @@ import (
 
 func main() {
 	fmt.Println("Welcome to the key-value store. Initialising...")
-	store := storage.NewKVStore()
+	var store storage.Store
+	store = storage.NewKVStore()
 	fmt.Println("Ready")
 	run(store)
 	defer fmt.Println("Exiting key-value store")
 }
 
-func run(store *storage.KVStore) {
+func run(store storage.Store) {
 	for {
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Print("Enter command: ")
@@ -31,7 +32,7 @@ func run(store *storage.KVStore) {
 	}
 }
 
-func process(cmd string, store *storage.KVStore) {
+func process(cmd string, store storage.Store) {
 	c := strings.Fields(cmd)
 	switch c[0] {
 	case "get":

--- a/pkg/storage/encode.go
+++ b/pkg/storage/encode.go
@@ -6,11 +6,11 @@ import (
 	"log"
 )
 
-// StrToBytes : Takes a string and encodes to bytes
-func StrToBytes(str string) []byte {
-	log.Printf("Encoding string %s to bytes", str)
+// Encode : Takes an undefined input and encodes to bytes
+func Encode(input interface{}) []byte {
+	log.Printf("Encoding input to bytes. Input: %s", input)
 	buff := &bytes.Buffer{}
-	gob.NewEncoder(buff).Encode(str)
+	gob.NewEncoder(buff).Encode(input)
 	bs := buff.Bytes()
 	log.Printf("Successfully encoded. Result: %v", bs)
 	return bs


### PR DESCRIPTION
# Overview 

This PR fixes some bugs and adds some steps towards getting a working flush to disk process

# Details

* Fixes Memtable instantiation so it is called with `Init()` rather than `New()` in order to properly `make()` the k-v map
* Add approx size variable onto Memtable to use to check flush rather than checking length everytime a new k-v pair set
* Record level and components on the kvs in style. E.g. [0]1 - Level 0 has 1 component. [1]2 - Level one has 2 components
* Update encode function to take any input rather than just string through an empty interface
* Add first step of checking current LSM tree L1 to know how to handle a memtable flush