### PR TITLE
Development 20200516

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	fmt.Println("Welcome to the key-value store. Initialising...")
 	var store storage.Store
-	store = storage.NewKVStore()
+	store = storage.KVStoreInit()
 	fmt.Println("Ready")
 	run(store)
 	defer fmt.Println("Exiting key-value store")

--- a/pkg/storage/kvstore.go
+++ b/pkg/storage/kvstore.go
@@ -1,7 +1,10 @@
 package storage
 
 import (
+	"fmt"
 	"log"
+	"os"
+	"time"
 )
 
 const (
@@ -17,27 +20,51 @@ type Store interface {
 
 // KVStore : represents the entirety of a key-value store
 type KVStore struct {
-	buffer     *Memtable
-	fanout     int
-	components map[int]int
+	buffer   *Memtable
+	fanout   int
+	manifest manifest
 }
 
-// NewKVStore : instantiates a new key-value store with some default values
-func NewKVStore() *KVStore {
-	log.Printf("Instantiating a new key-value store")
+// manifest : contains indexes and meta-data about LSMtree
+type manifest struct {
+	components  map[int]int
+	sstableList map[int]string
+}
+
+// KVStoreInit : instantiates a new key-value store with some default values
+func KVStoreInit() *KVStore {
+	log.Printf("Instantiating a new key-value store...")
 	log.Printf("Setting attributes: Memtable as buffer and level growth factor of %d", fanout)
 
-	mt := MemtableInit()
+	mem := MemtableInit()
+	mani := manifestInit()
+
 	kvs := &KVStore{
-		buffer:     mt,
-		fanout:     fanout,
-		components: make(map[int]int)}
+		buffer:   mem,
+		fanout:   fanout,
+		manifest: mani}
 
-	// memtable buffer represents one component in top level of kvs
-	kvs.components[0] = 1
+	log.Printf("Setting initial manifest data")
+	kvs.manifest.components[0] = 1 // memtable buffer represents one component in top level of kvs
 
-	log.Printf("Key-value store instantiated")
+	log.Printf("Creating directory lsmtree/ for SSTable files")
+	os.Mkdir("lsmtree", 0777)
+
+	log.Printf("Key-value store succesfully instantiated")
 	return kvs
+}
+
+// ManifestInit : creates a new manifest file, empty apart from C0
+func manifestInit() manifest {
+	log.Printf("Creating manifest")
+
+	m := manifest{
+		components:  make(map[int]int),
+		sstableList: make(map[int]string)}
+	log.Printf("Manifest successfully created")
+
+	return m
+
 }
 
 /*
@@ -50,120 +77,53 @@ func (kvs *KVStore) Set(key string, value string) error {
 	mt := kvs.buffer
 
 	val := Encode(value)
-
 	mt.InsertToMemtable(key, val)
 
-	switch f := mt.IsMemtableFull(); f {
-	case true:
+	f := mt.IsMemtableFull()
+	if f {
 		err := kvs.Flush()
-		log.Printf("%s: %s added to memtable and flushed to disk", key, value)
-
 		if err != nil {
 			return err
 		}
-
-	case false:
-		log.Printf("%s: %s added to memtable", key, value)
 	}
+
+	log.Printf("Congrats! %s: %s successfully stored", key, value)
 
 	return nil
 }
 
 // Flush : flushes memtable to disk as SSTable
 func (kvs *KVStore) Flush() error {
-	// TODO : create a new memtable while the last one is being written?
-	ss := kvs.buffer.NewSSTable()
+
+	log.Printf("Starting flush...")
+	ss := SSTableInit(kvs.buffer.kv)
+	kvs.buffer = MemtableInit()
+	log.Printf("Stored memtable and fresh empty memtable created")
+
 	kvs.WriteSSTableToDisk(ss)
 
 	return nil
 }
 
-/*
-READ OPERATIONS
-*/
+// Compaction : takes a set of files sorted by key and returns a new set of non-overlapping files sorted by key
+// might be called when level reaches certain threshold or for periodic reorganising of files on disk to maintain efficient
+func (kvs *KVStore) Compaction(inputFilesDir string) (string, error) {
 
-// Get : main function to get a key's value from the key-value store
-func (kvs *KVStore) Get(key string) ([]byte, error) {
-	var results []byte
+	log.Printf("Starting compaction...")
+	log.Printf("Compacting files stored at tmp file dir %s", inputFilesDir)
 
-	results, p, err := kvs.buffer.SearchMemtable(key)
+	log.Printf("Creating new tmp dir to store output")
+	now := time.Now().Unix()
+	outputFilesDir := fmt.Sprintf("outputFilesDir-%v", now)
+	os.Mkdir("outputFilesDir-", 0777)
+	log.Printf("New tmp dir created: %s", outputFilesDir)
 
-	if err != nil {
-		return nil, err
-	}
+	// TODO - DO THE COMPACTION (MERGE SORT)
 
-	if !p {
-		results, err = kvs.searchDisk(key)
+	log.Printf("Compaction complete. Returning new tmp file dir and remvoing old tmp file dir", outputFilesDir)
+	defer os.RemoveAll("inputFilesDir")
 
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return results, nil
-}
-
-// searchDisk : performs search on-disk for a given key
-func (kvs *KVStore) searchDisk(key string) ([]byte, error) {
-
-	indices, err := kvs.loadIndices()
-	if err != nil {
-		panic(err)
-	}
-
-	ir, err := kvs.searchIndices(indices)
-
-	result := kvs.getFromDisk(ir, key)
-
-	return result, nil
-}
-
-// loadIndices : loads indices of SStables into local memory
-func (kvs *KVStore) loadIndices() (map[string][]byte, error) {
-
-	indices := make(map[string][]byte)
-
-	// TODO ; for each SSTable, load its block index (key-off pairs) into a structure in local memory
-	// load all -> search one by one or load one -> search one ?
-
-	return indices, nil
-}
-
-// searchIndices : searches through key-offset pairs of all sstables in local memory
-func (kvs *KVStore) searchIndices(map[string][]byte) (map[string]map[string][]byte, error) {
-
-	var r map[string]map[string][]byte
-
-	// TODO - search through SStables from top level to bottom
-
-	result := r
-
-	return result, nil
-}
-
-// getFromDisk : returns a value for a key given a ssblock identifier, and key's approx location
-func (kvs *KVStore) getFromDisk(ir map[string]map[string][]byte, key string) []byte {
-	var results []byte
-	for _, r := range ir {
-		for tbl := range r {
-			print(tbl)
-			ss := new(SSTable) // TODO dummy overwrite -> change this to the search indices result
-			results = ss.GetValue(key)
-		}
-	}
-
-	return results
-}
-
-/*
-OTHER OPERATIONS
-*/
-
-// compaction : reorganises SSTables between levels of the tree to store efficiently
-func (kvs *KVStore) compaction() error {
-	return nil
-
-	// TODO implement a mergesort between sorted arrays
+	return outputFilesDir, nil
 
 	// if l1 is None: return l2
 	// if l2 is None: return l1
@@ -179,4 +139,91 @@ func (kvs *KVStore) compaction() error {
 	// elif l1.val == l2.val:
 	// 	return ListNode(l1.val,self.mergeTwoLists(l1.next,l2))
 	// return nil
+}
+
+/*
+READ OPERATIONS
+*/
+
+// Get : main function to get a key's value from the key-value store
+func (kvs *KVStore) Get(key string) ([]byte, error) {
+	var results []byte
+
+	results, present, err := kvs.buffer.SearchMemtable(key)
+	if err != nil {
+		return nil, err
+	}
+
+	if !present {
+		results, err = kvs.searchDisk(key)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return results, nil
+}
+
+// searchDisk : performs search on-disk for a given key
+func (kvs *KVStore) searchDisk(key string) ([]byte, error) {
+	log.Printf("Starting disk search...")
+
+	indices, err := kvs.loadIndices()
+	if err != nil {
+		panic(err)
+	}
+
+	ir, err := kvs.searchIndices(indices)
+	result := kvs.getFromDisk(ir, key)
+
+	return result, nil
+}
+
+// loadIndices : loads indices of SStables into local memory
+func (kvs *KVStore) loadIndices() (map[string][]byte, error) {
+
+	log.Printf("Loading indices...")
+
+	indices := make(map[string][]byte)
+
+	// TODO ; for each SSTable, load its block index (key-off pairs) into a structure in local memory
+	// load all -> search one by one or load one -> search one ?
+
+	return indices, nil
+}
+
+// searchIndices : searches through key-offset pairs of all sstables in local memory
+func (kvs *KVStore) searchIndices(map[string][]byte) (map[string]map[string][]byte, error) {
+
+	log.Printf("Searching indices...")
+
+	var r map[string]map[string][]byte
+
+	// TODO - search through SStables from top level to bottom
+
+	result := r
+
+	return result, nil
+}
+
+// getFromDisk : returns a value for a key given a ssblock identifier, and key's approx location
+func (kvs *KVStore) getFromDisk(ir map[string]map[string][]byte, key string) []byte {
+
+	log.Printf("Getting key-value from disk...")
+	// TODO
+
+	var results []byte
+
+	sst := new(SSTable)
+	results = sst.GetValue(key)
+
+	// for _, r := range ir {
+	// 	for tbl := range r {
+	// 		print(tbl)
+	// 		ss := new(SSTable) // TODO dummy overwrite -> change this to the search indices result
+	// 		results = ss.GetValue(key)
+	// 	}
+	// }
+
+	return results
 }

--- a/pkg/storage/memtable.go
+++ b/pkg/storage/memtable.go
@@ -28,7 +28,7 @@ func MemtableInit() (m *Memtable) {
 		kv:       make(map[string][]byte),
 		approxSz: 0,
 		max:      MaxMem}
-	log.Printf("Key-value store initialised with a memtable")
+	log.Printf("New memtable successfully created")
 
 	return memAddress
 
@@ -44,14 +44,12 @@ func (mt *Memtable) InsertToMemtable(key string, value []byte) (int error) {
 	if !present {
 		err := mt.insertKey(key)
 		mt.approxSz++
-
 		if err != nil {
 			return errors.New("Failed to insert key in memtable")
 		}
 	}
 
 	err = mt.setValueOnKey(key, value)
-
 	if err != nil {
 		return errors.New("Failed to set value against key in memtable")
 	}
@@ -61,7 +59,7 @@ func (mt *Memtable) InsertToMemtable(key string, value []byte) (int error) {
 
 // insertKey : inserts key in correct place in memtable using binary search
 func (mt *Memtable) insertKey(key string) error {
-	log.Printf("Finding correct place for key \"%s\" in memtable", key)
+	log.Printf("Finding correct place for key \"%s\" in memtable...", key)
 
 	// [TODO] - binary search to insert key in correct place
 
@@ -86,7 +84,6 @@ func (mt *Memtable) IsMemtableFull() bool {
 
 		return false
 	}
-
 	log.Printf("Memtable is full. Approx size: %d Max: %d", mt.approxSz, mt.max)
 
 	return true
@@ -98,7 +95,7 @@ READ OPERATIONS
 
 // SearchMemtable : given a key, tries to find an entry for it in memtable
 func (mt *Memtable) SearchMemtable(key string) ([]byte, bool, error) {
-	log.Printf("Searching memtable for key \"%s\"", key)
+	log.Printf("Searching memtable for key \"%s\"...", key)
 
 	value, present := mt.kv[key]
 

--- a/pkg/storage/sstable.go
+++ b/pkg/storage/sstable.go
@@ -1,9 +1,13 @@
 package storage
 
 import (
+	"bufio"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
+	"time"
 )
 
 // SSTable : represents a Sorted String Table on disk (kv : key-value pairs; index : key-offset pairs)
@@ -17,66 +21,71 @@ type SSTable struct {
 WRITE OPERATIONS
 */
 
-// NewSSTable : creates a new SStable from a given memtable
-func (mt *Memtable) NewSSTable() (ss *SSTable) {
+// SSTableInit : creates new SStable from a sorted set of key-value pairs
+func SSTableInit(kv map[string][]byte) (sst *SSTable) {
 
-	log.Printf("Creating a new SSTable")
+	log.Printf("Creating new SSTable")
 
-	// TODO group records into blocks and write to disk
-	// create a new memtable instance while I am doing this
+	fname := sst.createFileName()
 
 	return &SSTable{
-		fname: "",
-		kv:    mt.kv,
+		fname: fname,
+		kv:    kv,
 		index: make(map[string][]byte)}
+
+	// TODO group records into blocks?
+}
+
+// createFileName : set up file name where data will be written to
+func (sst *SSTable) createFileName() string {
+	log.Printf("Creating file name")
+
+	fileName := filepath.Join(
+		"lsmtree",
+		fmt.Sprintf("%v.dat", time.Now().Unix()),
+	)
+	log.Printf("Filename created: %v", fileName)
+
+	return fileName
 }
 
 // WriteSSTableToDisk : writes a SStable to disk
-func (kvs *KVStore) WriteSSTableToDisk(ss *SSTable) error {
-	log.Printf("Writing SSTable to disk")
+func (kvs *KVStore) WriteSSTableToDisk(sst *SSTable) error {
+	log.Printf("Writing SSTable to disk...")
 
-	log.Printf("Creating file for SSTable")
-	ss.fname = ss.createFileName()
-	file, err := os.Create(ss.fname)
-
-	log.Printf("Encoding SSTable data to bytes")
-	ssEncoded := Encode(ss)
-
+	log.Printf("Creating new file")
+	file, err := os.Create(sst.fname)
 	if err != nil {
 		panic(err)
 	}
 
+	log.Printf("Encoding SSTable data...")
+	sstEncoded := Encode(sst)
+
 	log.Printf("Checking status of level one of LSM tree")
-	_, present := kvs.components[1]
+	_, present := kvs.manifest.components[1]
 
 	if !present {
 		log.Printf("Level one of LSM tree does not exist yet. Flushing immediately")
-		nb, err := file.Write(ssEncoded)
-
+		nb, err := file.Write(sstEncoded)
 		if err != nil {
 			return err
 		}
 
 		log.Printf("Number of bytes written: %d", nb)
 	} else {
-		kvs.MergeSSTable(ss)
+		kvs.MergeSSTable(sst)
 	}
 
 	return nil
 }
 
-// createFileName : set up file name where data will be written to
-func (ss *SSTable) createFileName() string {
-	// TODO
-	return "0100.data"
-}
-
 // MergeSSTable : merges an SStable into existing disk structure
-func (kvs *KVStore) MergeSSTable(ss *SSTable) error {
+func (kvs *KVStore) MergeSSTable(ssy *SSTable) error {
 
 	maxComponents := 1 * kvs.fanout // TODO - determine when / how a level has reached max components
 
-	if kvs.components[1] == maxComponents {
+	if kvs.manifest.components[1] == maxComponents {
 		// TODO - level 1 merged into level 2
 		// C0 is now level 1
 	}
@@ -88,23 +97,40 @@ func (kvs *KVStore) MergeSSTable(ss *SSTable) error {
 READ OPERATIONS
 */
 
-// // SearchSSTable : search in index of one SSTable for given key
-// func (*SSTable) SearchSSTable(key string) []byte {
-// 	return []byte{1, 2, 3}
-// }
-
 // GetValue : read disk from approximate starting point to locate key and return its value
-func (ss *SSTable) GetValue(key string) []byte {
-	file, err := os.Open(ss.fname)
-	bArr := make([]byte, 10)
-	value, err := file.Read(bArr)
-	file.Close()
+func (sst *SSTable) GetValue(key string) []byte {
 
+	log.Printf("Creating key-value from SSTable: %s", sst.fname)
+
+	log.Printf("Opening file")
+	file, err := os.Open("lsmtree/1589638784.dat") // TODO - change this to open a sst.fname
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("%v", value)
+	defer func() {
+		if err = file.Close(); err != nil {
+			log.Fatal(err)
+		}
+	}()
 
-	return []byte{1, 2}
+	log.Printf("Creating new file scanner")
+	scanner := bufio.NewScanner(file)
+	log.Printf("Scanning...")
+	scanner.Scan()
+
+	// text := scanner.Text()
+	data := scanner.Bytes()
+
+	sstable := SSTable{}
+
+	log.Printf("Decoding")
+	decoded := json.Unmarshal(data, sstable) //TODO
+	// decoded := DecodeToSST(data)
+	log.Printf("Decoded")
+	fmt.Printf("%v", decoded)
+
+	// TODO - can access the SSTable as bytes - need to decode back to SSTable format first or access key-value and decode only this?
+
+	return data
 }


### PR DESCRIPTION
# Overview

This PR contains some improvements mainly to the set key and flush processes in the KVStore

# Details

* SSTables now can get written to disk as a file
* Filenames created using `unix.Now()`
* Manifest struct defined and manifest is created on initialising the store
* Tmp file directories creation added for compaction process
